### PR TITLE
Fix name error

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -40,7 +40,7 @@ def eigen_matrix_info(val):
     # Fixed size matrices have a struct as their storage
     if data.type.code == gdb.TYPE_CODE_STRUCT:
         data = data['array']
-        data = data.cast(self.innerType.pointer())
+        data = data.cast(innerType.pointer())
 
     return rows, cols, rowMajor, innerType, data
 


### PR DESCRIPTION
Firstly, thanks for the nice implementation as I've been trying to find a pretty printer that supports Eigen's Map matrix!

This just fix a tiny error as `self` does not exists in that scope.